### PR TITLE
Version 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## V0.6.1 - 2024-04-15
+
+- Fixed the `claim_filing_indicator_code` validator in the `OtherSubscriberInformation` model.
+
 ## V0.6.0 - 2023-11-17
 
 - Add the `meta` object to the response model.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    change_healthcare-professional_claims (0.6.0)
+    change_healthcare-professional_claims (0.6.1)
       addressable (~> 2.5)
       typhoeus (~> 1.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.1)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     backport (1.1.2)
@@ -18,9 +18,9 @@ GEM
     diff-lcs (1.4.4)
     docile (1.3.5)
     e2mmap (0.1.0)
-    ethon (0.15.0)
+    ethon (0.16.0)
       ffi (>= 1.15.0)
-    ffi (1.15.5)
+    ffi (1.16.3)
     jaro_winkler (1.5.4)
     kramdown (2.3.1)
       rexml
@@ -37,7 +37,7 @@ GEM
     pry (0.14.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (5.0.0)
+    public_suffix (5.0.5)
     racc (1.5.2)
     rainbow (3.0.0)
     rake (10.5.0)
@@ -95,7 +95,7 @@ GEM
       yard (~> 0.9, >= 0.9.24)
     thor (1.1.0)
     tilt (2.0.10)
-    typhoeus (1.4.0)
+    typhoeus (1.4.1)
       ethon (>= 0.9.0)
     unicode-display_width (2.0.0)
     yard (0.9.26)
@@ -115,4 +115,4 @@ DEPENDENCIES
   solargraph
 
 BUNDLED WITH
-   2.1.4
+   2.2.33

--- a/lib/change_healthcare/professional_claims/swagger_client/models/other_subscriber_information.rb
+++ b/lib/change_healthcare/professional_claims/swagger_client/models/other_subscriber_information.rb
@@ -180,7 +180,7 @@ module ChangeHealthcare
           return false unless benefits_assignment_certification_indicator_validator.valid?(@benefits_assignment_certification_indicator)
 
           claim_filing_indicator_code_validator = EnumAttributeValidator.new('String',
-                                                                             %w[11 12 13 14 15 16 17 AM BL CH DS FI HM LM
+                                                                             %w[11 12 13 14 15 16 17 AM BL CH CI DS FI HM LM
                                                                                 MA MB MC OF TV VA WC ZZ])
           return false unless claim_filing_indicator_code_validator.valid?(@claim_filing_indicator_code)
 
@@ -218,7 +218,7 @@ module ChangeHealthcare
         # @param [Object] claim_filing_indicator_code Object to be assigned
         def claim_filing_indicator_code=(claim_filing_indicator_code)
           validator = EnumAttributeValidator.new('String',
-                                                 %w[11 12 13 14 15 16 17 AM BL CH DS FI HM LM MA MB MC OF TV VA WC ZZ])
+                                                 %w[11 12 13 14 15 16 17 AM BL CH CI DS FI HM LM MA MB MC OF TV VA WC ZZ])
           unless validator.valid?(claim_filing_indicator_code)
             raise ArgumentError,
                   %(invalid value for "claim_filing_indicator_code", must be one of #{validator.allowable_values}.)

--- a/lib/change_healthcare/professional_claims/version.rb
+++ b/lib/change_healthcare/professional_claims/version.rb
@@ -2,6 +2,6 @@
 
 module ChangeHealthcare
   module ProfessionalClaims
-    VERSION = '0.6.0'
+    VERSION = '0.6.1'
   end
 end


### PR DESCRIPTION
Fixes the `claim_filing_indicator_code` validator in the `OtherSubscriberInformation` model, which was not accepting the value "CI" even though it should.